### PR TITLE
feat(argocd): add Application for proseed-postgres

### DIFF
--- a/k8s/argocd/applications/proseed/postgres.yaml
+++ b/k8s/argocd/applications/proseed/postgres.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: proseed-postgres
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/skkuding/proseed
+      targetRevision: main
+      path: infra/k8s/postgres
+      kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: proseed-postgres
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary
- `infra/k8s/postgres/`를 ArgoCD로 관리하기 위한 Application 추가
- api.yaml 패턴 기반, Image Updater annotation 제외 (공식 postgres 이미지)
- namespace: `proseed-postgres`

Closes #2
Related: skkuding/proseed#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)