### PR TITLE
fix(promtail): add liveness probe and raise cpu limit

### DIFF
--- a/k8s/observability/promtail/values.yaml
+++ b/k8s/observability/promtail/values.yaml
@@ -6,11 +6,21 @@ service:
 
 resources:
   limits:
-    cpu: 200m
+    cpu: 500m # raised from 200m: usage pegged the limit under load, CFS throttling starved the HTTP server and readiness probe
     memory: 128Mi
   requests:
     cpu: 100m
     memory: 128Mi
+
+# liveness probe so a wedged Promtail self-heals; without it a hung process stays not-ready forever (readiness only removes traffic, never restarts)
+livenessProbe:
+  httpGet:
+    path: /ready
+    port: http-metrics
+  initialDelaySeconds: 60 # let a fresh pod replay its position backlog before we judge liveness
+  periodSeconds: 30
+  timeoutSeconds: 2 # more slack than readiness (1s): a liveness kill is more disruptive than dropping from endpoints
+  failureThreshold: 6 # ~3min sustained unresponsiveness before restart, avoids flapping on transient stalls
 
 # enable Promtail ServiceMonitor for Prometheus Operator
 serviceMonitor:


### PR DESCRIPTION
## 배경

lab 클러스터 promtail 파드(`promtail-nhtvg`)가 **113일간 0/1 Ready, 0 restarts** 상태로 방치됨. `Readiness probe failed: Get "http://10.42.0.119:3101/ready": context deadline exceeded`가 약 103만 회 발생.

조사 결과 프로세스가 **wedged**(약 34일간 로그 0, `/ready`·`/metrics` 무응답, CPU가 limit 200m에 완전 pegged)였으나 아무것도 재시작하지 않아 로그 수집이 그동안 멈춰 있었음. 파드를 삭제해 DaemonSet이 재생성하니 17초 만에 Ready 복구 → 일회성 wedge였고 config 강제가 아님을 확인.

## 근본 원인

| 층 | 문제 |
|---|---|
| 자가치유 | **livenessProbe 부재** — readiness는 Service endpoint에서 빼기만 할 뿐 hung 프로세스를 재시작하지 않음 → wedge가 영구 지속 |
| 리소스 | **CPU limit 200m** — 부하 시 usage가 limit에 붙어 CFS throttle 발생 → HTTP server가 스케줄을 못 받아 `/ready`가 1s 타임아웃 |

## 변경

- 기존 `/ready` 엔드포인트에 **livenessProbe 추가**. 임계값을 여유롭게(`initialDelaySeconds 60`, `periodSeconds 30 × failureThreshold 6 ≈ 3분`) 잡아 정상적인 backlog replay 중 오탐 재시작을 피하고, 실제 wedge만 자동 복구.
- **CPU limit 200m → 500m**. 관측 peak 199m 대비 헤드룸 확보로 throttle-starvation 재발 방지.

## 검증

- 즉시 조치로 파드 재시작 완료 — 새 파드 `promtail-n9xdd` **1/1 Ready** (CPU 130m / Mem 105Mi), readiness 실패 이벤트 없음, 최신 로그 정상 수집.
- 초기 로그의 `400 timestamp too old`는 wedge 기간 누적된 옛 오프셋을 재전송하며 Loki 7일 retention을 초과해 거부되는 정상 backlog 현상. 최신 지점까지 따라잡으면 소멸.

## 후속 고려 (이 PR 범위 밖)

- **Memory limit 128Mi**가 관측 usage 105~120Mi 대비 빠듯함 (약 94%). backlog replay 시 OOMKill 여지 있어 별도 상향 검토 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)