### PR TITLE
chore(infra): right-size Loki cache memory

### DIFF
--- a/k8s/observability/loki/values.yaml
+++ b/k8s/observability/loki/values.yaml
@@ -40,6 +40,12 @@ loki:
 gateway:
   enabled: false
 
+chunksCache:
+  allocatedMemory: 4096
+
+resultsCache:
+  allocatedMemory: 512
+
 # default minio by loki chart
 # need to be replaced by custom minio(observability-minio) for centralized storage
 minio:


### PR DESCRIPTION
## 변경 사항

- Loki chunks cache 할당을 8Gi에서 4Gi로 조정
- Loki results cache 할당을 1Gi에서 512Mi로 조정
- Helm이 계산하는 memory request/limit을 각각 4915Mi, 614Mi로 축소

## 배경

lab 노드의 memory requests가 91%까지 올라가 있었으며, Loki 캐시 두 개가 약 11Gi를 차지하고 있었습니다. 현재 실제 사용량(chunks 약 783Mi, results 약 29Mi)보다 충분한 여유를 유지하면서 staging workload를 수용할 스케줄링 공간을 확보합니다.

## 검증

- Grafana Loki Helm chart `6.49.0`으로 template 렌더 성공
- chunks memcached: `-m 4096`, request/limit `4915Mi`
- results memcached: `-m 512`, request/limit `614Mi`

병합 후 ArgoCD sync와 cache eviction/OOM 여부를 관찰해야 합니다.