### PR TITLE
Feat/proseed prod release

### DIFF
--- a/k8s/argocd/applications/proseed/api.yaml
+++ b/k8s/argocd/applications/proseed/api.yaml
@@ -4,8 +4,8 @@ metadata:
   name: proseed-api
   namespace: argocd
   annotations:
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/skkuding/proseed/api
-    argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/skkuding/proseed/api:prod
+    argocd-image-updater.argoproj.io/api.update-strategy: digest
     argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -13,7 +13,7 @@ spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
+      targetRevision: release
       path: infra/k8s/api
       kustomize: {}
   destination:

--- a/k8s/argocd/applications/proseed/postgres.yaml
+++ b/k8s/argocd/applications/proseed/postgres.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
+      targetRevision: release
       path: infra/k8s/postgres
       kustomize: {}
   destination:

--- a/k8s/argocd/applications/proseed/web.yaml
+++ b/k8s/argocd/applications/proseed/web.yaml
@@ -4,8 +4,8 @@ metadata:
   name: proseed-web
   namespace: argocd
   annotations:
-    argocd-image-updater.argoproj.io/image-list: web=ghcr.io/skkuding/proseed/web
-    argocd-image-updater.argoproj.io/web.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/image-list: web=ghcr.io/skkuding/proseed/web:prod
+    argocd-image-updater.argoproj.io/web.update-strategy: digest
     argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -13,7 +13,7 @@ spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
+      targetRevision: release
       path: infra/k8s/web
       kustomize: {}
   destination:


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge until `skkuding/proseed/release` is synchronized with the current `main`.**
>
> 현재 확인 기준으로 `release`는 `a5dc87b`, 운영 `main`은 `d47feb0`입니다. 이 상태에서 이 PR을 먼저 머지하면 ArgoCD가 과거 release revision을 동기화해 Production이 롤백될 수 있습니다.
>
> 먼저 ProSeed의 `main -> release` 동기화를 완료하고 두 브랜치 SHA가 동일한지 확인해야 합니다.

## Summary

ProSeed 운영 환경의 배포 기준을 `main`에서 `release` 브랜치로 분리합니다.

## Changes

- API, Web, PostgreSQL ArgoCD Application의 `targetRevision`을 `main`에서 `release`로 변경
- API와 Web이 각각 GHCR의 `:prod` 태그만 추적하도록 제한
- Image Updater 전략을 `newest-build`에서 `digest`로 변경
- 기존 namespace와 자동 동기화 정책은 유지

## Why

기존에는 운영 환경이 `main`과 최신 이미지 태그를 직접 추적하여, Stage용 이미지가 운영에 반영될 가능성이 있었습니다.

이번 변경으로 배포 흐름을 다음과 같이 분리합니다.

- `main` → Stage 자동 배포
- Stage 검증 완료
- `main` → `release` 승격
- `release` → Production 배포

이를 통해 Stage에서 검증된 커밋만 운영 환경으로 승격할 수 있습니다.

## Deployment Impact

- 이 PR 머지 이후 `main` 변경 사항은 Production에 직접 반영되지 않습니다.
- Production은 `release` 브랜치와 `:prod` 이미지 태그만 추적합니다.
- API와 Web은 `:prod` 태그의 digest가 변경될 때 업데이트됩니다.
- 최초 `:prod` 이미지는 ProSeed 저장소의 첫 `main → release` 승격 시 CI가 자동 생성합니다.

## Validation

- [x] API Application manifest server-side dry-run 통과
- [x] Web Application manifest server-side dry-run 통과
- [x] PostgreSQL Application manifest server-side dry-run 통과
- [x] 기존 namespace 및 ArgoCD 자동 동기화 정책 유지 확인
- [x] 변경 범위가 ProSeed 운영 Application 3개로 제한됨을 확인

Related to skkuding/proseed#76