### PR TITLE
fix(argocd): safeguard Proseed production 

### DIFF
--- a/k8s/argocd/applications/proseed/api.yaml
+++ b/k8s/argocd/applications/proseed/api.yaml
@@ -3,10 +3,6 @@ kind: Application
 metadata:
   name: proseed-api
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/skkuding/proseed/api
-    argocd-image-updater.argoproj.io/api.update-strategy: newest-build
-    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -15,14 +11,13 @@ spec:
     - repoURL: https://github.com/skkuding/proseed
       targetRevision: main
       path: infra/k8s/api
-      kustomize: {}
+      kustomize:
+        images:
+          - ghcr.io/skkuding/proseed/api:3013d61c7199fb629c1b38151629c02a3676d87b
   destination:
     server: https://kubernetes.default.svc
     namespace: proseed
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/k8s/argocd/applications/proseed/postgres.yaml
+++ b/k8s/argocd/applications/proseed/postgres.yaml
@@ -16,9 +16,6 @@ spec:
     server: https://kubernetes.default.svc
     namespace: proseed-postgres
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/k8s/argocd/applications/proseed/web.yaml
+++ b/k8s/argocd/applications/proseed/web.yaml
@@ -3,10 +3,6 @@ kind: Application
 metadata:
   name: proseed-web
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: web=ghcr.io/skkuding/proseed/web
-    argocd-image-updater.argoproj.io/web.update-strategy: newest-build
-    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -15,14 +11,13 @@ spec:
     - repoURL: https://github.com/skkuding/proseed
       targetRevision: main
       path: infra/k8s/web
-      kustomize: {}
+      kustomize:
+        images:
+          - ghcr.io/skkuding/proseed/web:a4342c6de786dcbdeefab9ced636943e73238d46
   destination:
     server: https://kubernetes.default.svc
     namespace: proseed
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true


### PR DESCRIPTION
## 변경사항
- Production 이미지 SHA 고정: 현재 실행 중인 ProSeed Production API 및 Web의 이미지 태그를 고정된 SHA 값으로 지정했습니다.
- ArgoCD Image Updater 어노테이션 임시 제거:  자동 이미지 갱신 설정을 임시로 삭제했습니다.
- Auto-sync 임시 비활성화: API, Web, Postgres Application의 자동 동기화 설정을 껐습니다.

## 작업 배경 
- Staging과 Production의 GitOps 레이아웃을 분리하는 동안, 새롭게 추가된 :stage 이미지나 Feature/PR 이미지에 의해 Production Application이 의도치 않게 배포되는 현상을 방지하기 위함입니다.