### PR TITLE
feat(argocd): deploy ProSeed staging applications

### DIFF
--- a/k8s/argocd/applications/proseed/api-stage.yaml
+++ b/k8s/argocd/applications/proseed/api-stage.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: proseed-api-stage
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '2'
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/skkuding/proseed/api:stage
+    argocd-image-updater.argoproj.io/api.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/skkuding/proseed
+      targetRevision: main
+      path: infra/k8s/api/overlays/staging
+      kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: proseed-stage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/k8s/argocd/applications/proseed/postgres-stage.yaml
+++ b/k8s/argocd/applications/proseed/postgres-stage.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: proseed-postgres-stage
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/skkuding/proseed
+      targetRevision: main
+      path: infra/k8s/postgres/overlays/staging
+      kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: proseed-stage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/k8s/argocd/applications/proseed/web-stage.yaml
+++ b/k8s/argocd/applications/proseed/web-stage.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: proseed-web-stage
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '1'
+    argocd-image-updater.argoproj.io/image-list: web=ghcr.io/skkuding/proseed/web:stage
+    argocd-image-updater.argoproj.io/web.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/skkuding/proseed
+      targetRevision: main
+      path: infra/k8s/web/overlays/staging
+      kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: proseed-stage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## 변경사항 
- Staging ArgoCD Application 추가: Proseed Stage의 Postgres, Web, API를 위한 ArgoCD Application을 추가했습니다.
- 네임스페이스 격리: 모든 리소스를 `proseed-stage` 네임스페이스 내에 유지합니다.
- 순차 배포를 위한 Sync Wave 적용: Postgres(0) -> Web(1) -> API(2) 순서로 Sync Wave를 지정했습니다.
- 이미지 추적 전략: 명시적인 `:stage` 태그를 추적하되, digest 전략을 함께 활용하도록 설정했습니다. (연관 PR: proseed #137)


* Production Application 매니페스트에는 아무런 변경사항이 없습니다.
* Production 환경은 자동 동기화가 비활성화된 상태로 고정된 이미지를 유지합니다.