### PR TITLE
feat(infra): promote ProSeed production release

### DIFF
--- a/k8s/argocd/applications/proseed/api.yaml
+++ b/k8s/argocd/applications/proseed/api.yaml
@@ -3,17 +3,19 @@ kind: Application
 metadata:
   name: proseed-api
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/skkuding/proseed/api:prod
+    argocd-image-updater.argoproj.io/api.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
-      path: infra/k8s/api
-      kustomize:
-        images:
-          - ghcr.io/skkuding/proseed/api:3013d61c7199fb629c1b38151629c02a3676d87b
+      targetRevision: release
+      path: infra/k8s/api/overlays/production
+      kustomize: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: proseed

--- a/k8s/argocd/applications/proseed/postgres.yaml
+++ b/k8s/argocd/applications/proseed/postgres.yaml
@@ -3,14 +3,18 @@ kind: Application
 metadata:
   name: proseed-postgres
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: backup=ghcr.io/skkuding/proseed/postgres-backup:prod
+    argocd-image-updater.argoproj.io/backup.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
-      path: infra/k8s/postgres
+      targetRevision: release
+      path: infra/k8s/postgres/overlays/production
       kustomize: {}
   destination:
     server: https://kubernetes.default.svc

--- a/k8s/argocd/applications/proseed/web.yaml
+++ b/k8s/argocd/applications/proseed/web.yaml
@@ -3,17 +3,19 @@ kind: Application
 metadata:
   name: proseed-web
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: web=ghcr.io/skkuding/proseed/web:prod
+    argocd-image-updater.argoproj.io/web.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:
     - repoURL: https://github.com/skkuding/proseed
-      targetRevision: main
-      path: infra/k8s/web
-      kustomize:
-        images:
-          - ghcr.io/skkuding/proseed/web:a4342c6de786dcbdeefab9ced636943e73238d46
+      targetRevision: release
+      path: infra/k8s/web/overlays/production
+      kustomize: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: proseed


### PR DESCRIPTION
## 변경사항
- Production 타겟 브랜치 설정: Production API, Web, Postgres Application이 release 브랜치 및 Production Overlay 경로를 추적하도록 변경했습니다.
- Image Updater 도입: 가변 태그(api:prod, web:prod, postgres-backup:prod)를 추적하되, digest 전략을 적용해 고정된 SHA-256 디제스트로 자동 변환·기록하도록 설정했습니다.

## 작업 배경
- Staging은 main 브랜치를 추적하지만, Production은 검증을 거쳐 승격된 release 브랜치만 배포받아야 합니다. :prod 태그를 직접 바라보더라도 digest 전략을 사용하면 ArgoCD가 실제 고정된 이미지 해시(SHA-256) 값으로 매핑해 주므로 안정성을 확보할 수 있습니다.

- 배포 영향
- ArgoCD Application의 desired state가 갱신되고 Image Updater가 :prod 태그의 고정 디제스트를 추적하기 시작합니다. 자동 동기화가 비활성화되어 있으므로 수동 Sync 전까지는 운영 워크로드에 변경이 적용되지 않습니다.

롤백 계획 (Rollback)
Sync 전: PR Revert 진행
배포 후: 해당 Application의 이미지 디제스트를 이전 값으로 재설정 후 Sync (API 롤백 시 DB 마이그레이션 호환성 확인 필요)