### PR TITLE
feat(infra): enable ProSeed production auto sync

### DIFF
--- a/k8s/argocd/applications/proseed/api.yaml
+++ b/k8s/argocd/applications/proseed/api.yaml
@@ -20,6 +20,10 @@ spec:
     server: https://kubernetes.default.svc
     namespace: proseed
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - PruneLast=true

--- a/k8s/argocd/applications/proseed/postgres.yaml
+++ b/k8s/argocd/applications/proseed/postgres.yaml
@@ -20,6 +20,10 @@ spec:
     server: https://kubernetes.default.svc
     namespace: proseed-postgres
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - PruneLast=true

--- a/k8s/argocd/applications/proseed/web.yaml
+++ b/k8s/argocd/applications/proseed/web.yaml
@@ -20,6 +20,10 @@ spec:
     server: https://kubernetes.default.svc
     namespace: proseed
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - PruneLast=true


### PR DESCRIPTION
## What changed

- Enable automated sync, self-heal, and prune for the Production API, Web, and Postgres Applications.
- Add `PruneLast=true` so removed resources are pruned after other sync work completes.
- Keep `allowEmpty` disabled.

## Why

Production now tracks promoted `release` manifests and mutable `:prod` tags by digest. Enabling automated sync completes the GitOps flow from release promotion to deployment, while self-heal restores manual drift and prune removes resources deleted from Git.

## Validation

- All three Application manifests passed Kubernetes server dry-run.
- `git diff --check` passed.
- Current Production API, Web, Postgres, and backup are `Synced/Healthy` before this policy-only change.

## Deployment impact

Merging this PR does not change the current rendered workloads because all three Applications are already synced to the current release digests. Future `release` manifest changes or `:prod` digest updates will deploy automatically.

## Safety notes

- `PruneLast=true` delays deletion until the final sync phase.
- `allowEmpty` remains disabled to prevent an empty render from pruning the whole Application.
- Removing a real resource from the `release` manifests will now remove it from the cluster automatically, so Production manifest deletions require careful review.

## Rollback

Revert this PR to disable automated sync, self-heal, and prune. Existing workloads remain deployed at their current state.
